### PR TITLE
Checking if the relative path fixes the issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ I'm undertaking this project as part of the [Open Life Science](openlifesci.org)
 Anybody who is interested in this topic: data stewards, policy advisors, researchers, and others.
 
 ## How can I contribute?
-Great that you want to contribute! I am still looking for data stewards to take my survey. The link to my survey will follow shortly. Participation is entirely voluntary, and this is a project that I undertook on my own initiative and that is not mandated by my employer. You can find out exactly how to contribute in my [Contributing guidelines](Contributing.md). You can also [get in touch](https://docs.google.com/forms/d/e/1FAIpQLSfxozn8C0s3hObYaafc6HVU5TDrRu3V9ObkMmlCxjXHjIl5Nw/viewform?usp=sf_link) with the project lead. I value contributions from anyone who is interested in the topic. Please also read my [Code of Conduct](Code-of-Conduct.md).
+Great that you want to contribute! I am still looking for data stewards to take my survey. The link to my survey will follow shortly. Participation is entirely voluntary, and this is a project that I undertook on my own initiative and that is not mandated by my employer. You can find out exactly how to contribute in my [Contributing guidelines](./Contributing.md). You can also [get in touch](https://docs.google.com/forms/d/e/1FAIpQLSfxozn8C0s3hObYaafc6HVU5TDrRu3V9ObkMmlCxjXHjIl5Nw/viewform?usp=sf_link) with the project lead. I value contributions from anyone who is interested in the topic. Please also read my [Code of Conduct](./Code-of-Conduct.md).
 
 ## How do I cite this repository?
 This repository was licenced under a CC0 licence, but I would appreciate it if you cited me when you reuse content. You can cite this repository as follows: 


### PR DESCRIPTION
Trying to fix this issue:
> The published page on GitHub pages is here: https://elisa-on-github.github.io/Generic-data-stewards/
For some reason, when you click the hyperlink on "Contributing guidelines" you are made to download the Markdown file (presumably?) while the hyperlink for the CoC links you, correctly, to the relevant page on the website. I added both hyperlinks in exactly the same way. What's going on?